### PR TITLE
Fix: handleRouteChange arg type

### DIFF
--- a/lib/gtag.ts
+++ b/lib/gtag.ts
@@ -1,7 +1,7 @@
 export const GA_TRACKING_ID = ''
 
 // https://developers.google.com/analytics/devguides/collection/gtagjs/pages
-export const pageview = (url: URL): void => {
+export const pageview = (url: string): void => {
   if (window && window.gtag) {
     window.gtag('config', GA_TRACKING_ID, {
       page_path: url,

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -12,7 +12,7 @@ const App: React.FC<AppProps> = ({ Component, pageProps }) => {
   const router = useRouter()
 
   useEffect(() => {
-    const handleRouteChange = (url: URL) => {
+    const handleRouteChange = (url: string) => {
       gtag.pageview(url)
     }
     router.events.on('routeChangeComplete', handleRouteChange)

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -12,8 +12,8 @@ const App: React.FC<AppProps> = ({ Component, pageProps }) => {
   const router = useRouter()
 
   useEffect(() => {
-    const handleRouteChange = (url: string) => {
-      gtag.pageview(url)
+    const handleRouteChange = (url: string, options: { shallow?: boolean }) => {
+      if (!options.shallow) gtag.pageview(url)
     }
     router.events.on('routeChangeComplete', handleRouteChange)
     return () => {


### PR DESCRIPTION
- Fix handleRouteChange arg type: `URL` interface -> `string`
- Fix double sending PV for static page with params